### PR TITLE
🎁 Added the command composer install when starting the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ./api_manager:/var/www
     depends_on:
       - db
+    command: bash -c "composer install && php-fpm"
     container_name: chamomile_app
 
   db:


### PR DESCRIPTION
**Docker conteiner**
When starting and setting up the Docker container `chamomile_app`, a command will be executed inside this container to run and install all `Composer` dependencies.